### PR TITLE
fix sine formula displaying

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -250,6 +250,10 @@
   };
 
   window.GraphUtils = {
+    TAU: "\u03c4",
+    PI: "\u03c0",    // because now nobody complains about this
+    CENTERDOT: "\u00b7",
+
     superscript(string) {
       return Array.from(string).map(char_ => SUPERSCRIPTS[char_] || char_).join("");
     },

--- a/sine.html
+++ b/sine.html
@@ -4,9 +4,9 @@
     <link rel="stylesheet" href="./css/graph.css"></link>
     <script type="text/javascript" src="./js/graph.js"></script>
     <script type="text/javascript">
-    const getEquationString = (A,f) => ("y = " +
-      GraphUtils.parenthesize(A.toString()) + "sin(τ" +
-      GraphUtils.numberTimesText(f, "x") +")");
+    const getEquationString = (A,f) => "y = " + GraphUtils.numberTimesText(
+      A, "sin(" + GraphUtils.TAU + GraphUtils.CENTERDOT +
+         GraphUtils.parenthesize(f.toString()) + "x)");
 
     document.addEventListener("DOMContentLoaded", () => {
       const graph = new Graph([["amplitude", 1], ["frequency", 1]],


### PR DESCRIPTION
changes:
- now there's a `·` multiplication sign after τ to make it less confusing
- amplitude=-2 gives `y=-2sin(blablabla)` instead of `y=(-2)sin(blablabla)`
- frequency=-1 gives `sin(τ·(-1)x)` instead of `sin(τ-x)`, this was a bug that I didn't notice earlier